### PR TITLE
Fixed format byte for encoding larger arrays and maps

### DIFF
--- a/Sources/MessagePack/Encoder/KeyedEncodingContainer.swift
+++ b/Sources/MessagePack/Encoder/KeyedEncodingContainer.swift
@@ -67,11 +67,11 @@ extension _MessagePackEncoder.KeyedContainer: _MessagePackEncodingContainer {
             if length <= 15 {
                 data.append(0x80 + UInt8(length))
             } else {
-                data.append(0xdc)
+                data.append(0xde)
                 data.append(contentsOf: uint16.bytes)
             }
         } else if let uint32 = UInt32(exactly: length) {
-            data.append(0xdd)
+            data.append(0xdf)
             data.append(contentsOf: uint32.bytes)
         } else {
             fatalError()

--- a/Sources/MessagePack/Encoder/UnkeyedEncodingContainer.swift
+++ b/Sources/MessagePack/Encoder/UnkeyedEncodingContainer.swift
@@ -73,7 +73,7 @@ extension _MessagePackEncoder.UnkeyedContainer: _MessagePackEncodingContainer {
                 data.append(contentsOf: uint16.bytes)
             }
         } else if let uint32 = UInt32(exactly: length) {
-            data.append(0xdc)
+            data.append(0xdd)
             data.append(contentsOf: uint32.bytes)
         } else {
             fatalError()


### PR DESCRIPTION
First of all. Thank you very much for a great book. I really enjoyed reading it, especially the last chapter about MessagePack.

It seems like the format byte when encoding keyed containers larger than 15 element are incorrect, both for the case where the length is stored in a Int16 and if stored in Int32 according to the specification at 
https://github.com/msgpack/msgpack/blob/master/spec.md#map-format-family (and in the book.)

Further it seems to be incorrect for unkeyed containers where the length needs to be stored in a Int32 according to the specification at 
https://github.com/msgpack/msgpack/blob/master/spec.md#array-format-family

Let me know if you need more info.