### PR TITLE
Conditionalize implementation of hashValue when Hashable autosynthesis is unavailable

### DIFF
--- a/Sources/MessagePack/AnyCodingKey.swift
+++ b/Sources/MessagePack/AnyCodingKey.swift
@@ -22,7 +22,7 @@ struct AnyCodingKey: CodingKey, Equatable {
 }
 
 extension AnyCodingKey: Hashable {
-    #if swift(<4.1)
+    #if !swift(>=4.1)
     var hashValue: Int {
         return self.intValue?.hashValue ?? self.stringValue.hashValue
     }

--- a/Sources/MessagePack/AnyCodingKey.swift
+++ b/Sources/MessagePack/AnyCodingKey.swift
@@ -22,7 +22,9 @@ struct AnyCodingKey: CodingKey, Equatable {
 }
 
 extension AnyCodingKey: Hashable {
+    #if swift(<4.1)
     var hashValue: Int {
         return self.intValue?.hashValue ?? self.stringValue.hashValue
     }
+    #endif
 }


### PR DESCRIPTION
Fixes compiler warning "'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'AnyCodingKey' to 'Hashable' by implementing 'hash(into:)' instead"