### PR TITLE
Floating Point Values Decoding

### DIFF
--- a/Sources/MessagePack/Decoder/MessagePackDecoder.swift
+++ b/Sources/MessagePack/Decoder/MessagePackDecoder.swift
@@ -26,6 +26,7 @@ final public class MessagePackDecoder {
     public func decode<T>(_ type: T.Type, from data: Data) throws -> T where T : Decodable {
         let decoder = _MessagePackDecoder(data: data)
         decoder.userInfo = self.userInfo
+        decoder.userInfo[MessagePackDecoder.nonMatchingFloatDecodingStrategyKey] = nonMatchingFloatDecodingStrategy
         
         switch type {
         case is Data.Type:
@@ -37,6 +38,27 @@ final public class MessagePackDecoder {
         default:
             return try T(from: decoder)
         }
+    }
+
+    /**
+     The strategy used by a decoder when it encounters format mismatches for floating point values.
+     */
+    public var nonMatchingFloatDecodingStrategy: NonMatchingFloatDecodingStrategy = .strict
+
+    /**
+     The strategies for decoding floating point values when their format doesn't match.
+     */
+    public enum NonMatchingFloatDecodingStrategy {
+
+        /// Throws a DecodingError.typeMismatch
+        case strict
+
+        /// Performs a cast
+        case cast
+    }
+
+    internal static var nonMatchingFloatDecodingStrategyKey: CodingUserInfoKey {
+        return CodingUserInfoKey(rawValue: "nonMatchingFloatDecodingStrategyKey")!
     }
 }
 

--- a/Sources/MessagePack/Decoder/SingleValueDecodingContainer.swift
+++ b/Sources/MessagePack/Decoder/SingleValueDecodingContainer.swift
@@ -76,9 +76,6 @@ extension _MessagePackDecoder.SingleValueContainer: SingleValueDecodingContainer
     func decode(_ type: Double.Type) throws -> Double {
         let format = try readByte()
         switch format {
-        case 0xca:
-            let bitPattern = try read(UInt32.self)
-            return Double(bitPattern: UInt64(bitPattern))
         case 0xcb:
             let bitPattern = try read(UInt64.self)
             return Double(bitPattern: bitPattern)
@@ -93,11 +90,6 @@ extension _MessagePackDecoder.SingleValueContainer: SingleValueDecodingContainer
         switch format {
         case 0xca:
             let bitPattern = try read(UInt32.self)
-            return Float(bitPattern: bitPattern)
-        case 0xcb:
-            guard let bitPattern = UInt32(exactly: try read(UInt32.self)) else {
-                fallthrough
-            }
             return Float(bitPattern: bitPattern)
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(format)")

--- a/Sources/MessagePack/Decoder/SingleValueDecodingContainer.swift
+++ b/Sources/MessagePack/Decoder/SingleValueDecodingContainer.swift
@@ -44,7 +44,7 @@ extension _MessagePackDecoder.SingleValueContainer: SingleValueDecodingContainer
         case 0xc3: return true
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(format)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(Bool.self, context)
         }
     }
     
@@ -61,8 +61,7 @@ extension _MessagePackDecoder.SingleValueContainer: SingleValueDecodingContainer
         case 0xdb:
             length = Int(try read(UInt32.self))
         default:
-            let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(format)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.dataCorruptedError(in: self, debugDescription: "Invalid format for String length: \(format)")
         }
         
         let data = try read(length)
@@ -102,7 +101,7 @@ extension _MessagePackDecoder.SingleValueContainer: SingleValueDecodingContainer
             return Float(bitPattern: bitPattern)
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(format)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(Float.self, context)
         }
     }
     
@@ -166,7 +165,7 @@ extension _MessagePackDecoder.SingleValueContainer: SingleValueDecodingContainer
             seconds = TimeInterval(try read(Int64.self))
         default:
             let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(format)")
-            throw DecodingError.typeMismatch(Double.self, context)
+            throw DecodingError.typeMismatch(Date.self, context)
         }
         
         let timeInterval = TimeInterval(seconds) + nanoseconds / Double(NSEC_PER_SEC)
@@ -185,8 +184,7 @@ extension _MessagePackDecoder.SingleValueContainer: SingleValueDecodingContainer
         case 0xc6:
             length = Int(try read(UInt32.self))
         default:
-            let context = DecodingError.Context(codingPath: self.codingPath, debugDescription: "Invalid format: \(format)")
-            throw DecodingError.typeMismatch(UInt.self, context)
+            throw DecodingError.dataCorruptedError(in: self, debugDescription: "Invalid format for Data length: \(format)")
         }
         
         return self.data.subdata(in: self.index..<self.index.advanced(by: length))

--- a/Tests/MessagePackTests/MessagePackDecodingTests.swift
+++ b/Tests/MessagePackTests/MessagePackDecodingTests.swift
@@ -70,6 +70,9 @@ class MessagePackDecodingTests: XCTestCase {
         let data = Data(bytes: [0xCA, 0x40, 0x48, 0xF5, 0xC3])
         let type = assertTypeMismatch(try decoder.decode(Double.self, from: data))
         XCTAssertTrue(type is Double.Type)
+        decoder.nonMatchingFloatDecodingStrategy = .cast
+        let value = try! decoder.decode(Double.self, from: data)
+        XCTAssertEqual(value, 3.14, accuracy: 1e-6)
     }
     
     func testDecodeDouble() {
@@ -82,6 +85,9 @@ class MessagePackDecodingTests: XCTestCase {
         let data = Data(bytes: [0xCB, 0x40, 0x09, 0x21, 0xF9, 0xF0, 0x1B, 0x86, 0x6E])
         let type = assertTypeMismatch(try decoder.decode(Float.self, from: data))
         XCTAssertTrue(type is Float.Type)
+        decoder.nonMatchingFloatDecodingStrategy = .cast
+        let value = try! decoder.decode(Float.self, from: data)
+        XCTAssertEqual(value, 3.14159)
     }
     
     func testDecodeFixedArray() {

--- a/Tests/MessagePackTests/MessagePackDecodingTests.swift
+++ b/Tests/MessagePackTests/MessagePackDecodingTests.swift
@@ -10,7 +10,7 @@ class MessagePackDecodingTests: XCTestCase {
 
     func assertTypeMismatch<T>(_ expression: @autoclosure () throws -> T,
                                _ message: @autoclosure () -> String = "",
-                               file: StaticString = #filePath,
+                               file: StaticString = #file,
                                line: UInt = #line) -> Any.Type? {
         var error: Error?
         XCTAssertThrowsError(expression, message,
@@ -158,7 +158,7 @@ class MessagePackDecodingTests: XCTestCase {
         ("testDecodeFloat", testDecodeFloat),
         ("testDecodeFloatToDouble", testDecodeFloatToDouble),
         ("testDecodeDouble", testDecodeDouble),
-        ("testDecodeFloatToDouble", testDecodeFloatToDouble),
+        ("testDecodeDoubleToFloat", testDecodeDoubleToFloat),
         ("testDecodeFixedArray", testDecodeFixedArray),
         ("testDecodeFixedDictionary", testDecodeFixedDictionary),
         ("testDecodeData", testDecodeData),


### PR DESCRIPTION
Resolves https://github.com/Flight-School/MessagePack/issues/17 for `Float` to `Double` and `Double` to `Float` cases.

- By default throws `DecodingError.typeMismatch`
- If `nonMatchingFloatDecodingStrategy == .cast`, then performs a cast instead

The same flexibility can be added in a similar way for integer types.
