### PR TITLE
initial commit for supporting multiple CodingKeys

### DIFF
--- a/Sources/MessagePack/Decoder/MessagePackDecoder.swift
+++ b/Sources/MessagePack/Decoder/MessagePackDecoder.swift
@@ -78,8 +78,9 @@ final class _MessagePackDecoder {
     var codingPath: [CodingKey] = []
     
     var userInfo: [CodingUserInfoKey : Any] = [:]
-    
-    var container: MessagePackDecodingContainer?
+
+    var containers: [MessagePackDecodingContainer] = []
+    var container: MessagePackDecodingContainer? { containers.last }
     fileprivate var data: Data
     
     init(data: Data) {
@@ -89,14 +90,14 @@ final class _MessagePackDecoder {
 
 extension _MessagePackDecoder: Decoder {
     fileprivate func assertCanCreateContainer() {
-        precondition(self.container == nil)
+//        precondition(self.container == nil)
     }
         
     func container<Key>(keyedBy type: Key.Type) -> KeyedDecodingContainer<Key> where Key : CodingKey {
         assertCanCreateContainer()
 
         let container = KeyedContainer<Key>(data: self.data, codingPath: self.codingPath, userInfo: self.userInfo)
-        self.container = container
+        self.containers.append(container)
 
         return KeyedDecodingContainer(container)
     }
@@ -105,7 +106,7 @@ extension _MessagePackDecoder: Decoder {
         assertCanCreateContainer()
         
         let container = UnkeyedContainer(data: self.data, codingPath: self.codingPath, userInfo: self.userInfo)
-        self.container = container
+        self.containers.append(container)
 
         return container
     }
@@ -114,7 +115,7 @@ extension _MessagePackDecoder: Decoder {
         assertCanCreateContainer()
         
         let container = SingleValueContainer(data: self.data, codingPath: self.codingPath, userInfo: self.userInfo)
-        self.container = container
+        self.containers.append(container)
         
         return container
     }

--- a/Sources/MessagePack/Encoder/MessagePackEncoder.swift
+++ b/Sources/MessagePack/Encoder/MessagePackEncoder.swift
@@ -49,7 +49,7 @@ extension MessagePackEncoder: TopLevelEncoder {
 
 // MARK: -
 
-protocol _MessagePackEncodingContainer {
+protocol _MessagePackEncodingContainer: KeyedStorage {
     var data: Data { get }
 }
 
@@ -71,12 +71,20 @@ extension _MessagePackEncoder: Encoder {
     }
     
     func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
-        assertCanCreateContainer()
-        
-        let container = KeyedContainer<Key>(codingPath: self.codingPath, userInfo: self.userInfo)
-        self.container = container
-        
-        return KeyedEncodingContainer(container)
+//        assertCanCreateContainer()
+
+        guard let container = container else {
+            let container = KeyedContainer<Key>(codingPath: self.codingPath, userInfo: self.userInfo)
+            self.container = container
+
+            return KeyedEncodingContainer(container)
+        }
+
+        let newContainer = KeyedContainer<Key>(keyStorage: container.keyStorage)
+        self.container = newContainer
+
+
+        return KeyedEncodingContainer(newContainer)
     }
     
     func unkeyedContainer() -> UnkeyedEncodingContainer {

--- a/Sources/MessagePack/Encoder/SingleValueEncodingContainer.swift
+++ b/Sources/MessagePack/Encoder/SingleValueEncodingContainer.swift
@@ -3,21 +3,28 @@ import Foundation
 extension _MessagePackEncoder {
     final class SingleValueContainer {
         private var storage: Data = Data()
-        
+        var keyStorage: KeyStorage = KeyStorage()
+        var codingPath: [CodingKey] {
+            get {
+                keyStorage.codingPath
+            }
+
+            set {
+                keyStorage.codingPath = newValue
+            }
+        }
+
         fileprivate var canEncodeNewValue = true
         fileprivate func checkCanEncode(value: Any?) throws {
             guard self.canEncodeNewValue else {
-                let context = EncodingError.Context(codingPath: self.codingPath, debugDescription: "Attempt to encode value through single value container when previously value already encoded.")
+                let context = EncodingError.Context(codingPath: self.keyStorage.codingPath, debugDescription: "Attempt to encode value through single value container when previously value already encoded.")
                 throw EncodingError.invalidValue(value as Any, context)
             }
         }
         
-        var codingPath: [CodingKey]
-        var userInfo: [CodingUserInfoKey: Any]
-        
         init(codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) {
-            self.codingPath = codingPath
-            self.userInfo = userInfo
+            self.keyStorage.codingPath = codingPath
+            self.keyStorage.userInfo = userInfo
         }
     }
 }

--- a/Sources/MessagePack/Encoder/UnkeyedEncodingContainer.swift
+++ b/Sources/MessagePack/Encoder/UnkeyedEncodingContainer.swift
@@ -3,22 +3,28 @@ import Foundation
 extension _MessagePackEncoder {
     final class UnkeyedContainer {
         private var storage: [_MessagePackEncodingContainer] = []
-        
+        internal var keyStorage = KeyStorage()
+        var codingPath: [CodingKey] {
+            get {
+                keyStorage.codingPath
+            }
+
+            set {
+                keyStorage.codingPath = newValue
+            }
+        }
+
         var count: Int {
             return storage.count
         }
-        
-        var codingPath: [CodingKey]
         
         var nestedCodingPath: [CodingKey] {
             return self.codingPath + [AnyCodingKey(intValue: self.count)!]
         }
         
-        var userInfo: [CodingUserInfoKey: Any]
-        
         init(codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any]) {
-            self.codingPath = codingPath
-            self.userInfo = userInfo
+            self.keyStorage.codingPath = codingPath
+            self.keyStorage.userInfo = userInfo
         }
     }
 }
@@ -35,21 +41,21 @@ extension _MessagePackEncoder.UnkeyedContainer: UnkeyedEncodingContainer {
     }
     
     private func nestedSingleValueContainer() -> SingleValueEncodingContainer {
-        let container = _MessagePackEncoder.SingleValueContainer(codingPath: self.nestedCodingPath, userInfo: self.userInfo)
+        let container = _MessagePackEncoder.SingleValueContainer(codingPath: self.nestedCodingPath, userInfo: self.keyStorage.userInfo)
         self.storage.append(container)
 
         return container
     }
     
     func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-        let container = _MessagePackEncoder.KeyedContainer<NestedKey>(codingPath: self.nestedCodingPath, userInfo: self.userInfo)
+        let container = _MessagePackEncoder.KeyedContainer<NestedKey>(codingPath: self.nestedCodingPath, userInfo: self.keyStorage.userInfo)
         self.storage.append(container)
         
         return KeyedEncodingContainer(container)
     }
     
     func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
-        let container = _MessagePackEncoder.UnkeyedContainer(codingPath: self.nestedCodingPath, userInfo: self.userInfo)
+        let container = _MessagePackEncoder.UnkeyedContainer(codingPath: self.nestedCodingPath, userInfo: self.keyStorage.userInfo)
         self.storage.append(container)
         
         return container


### PR DESCRIPTION
Add very naïve support for encoding objects that inherits from an already Codable class when both contain custom CodingKeys. (see my issue: https://github.com/Flight-School/MessagePack/issues/19 )
Tested on my own (private) code for now.